### PR TITLE
Purgecss

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "license": "MIT",
     "dependencies": {
         "@fullhuman/postcss-purgecss": "^1.1.0",
+        "lodash": "^4.17.11",
         "tailwindcss": "^0.7.4"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "author": "Marco Mark <m2de@outlook.com>",
     "license": "MIT",
     "dependencies": {
+        "@fullhuman/postcss-purgecss": "^1.1.0",
         "tailwindcss": "^0.7.4"
     },
     "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ module.exports = {
 
 ## Configuration options
 
-You can overwrite the default configuration if required
+You can overwrite the default Tailwind CSS configuration if required, otherwise the default config will be loaded.
 
 ```js
 module.exports = {
@@ -27,6 +27,19 @@ module.exports = {
     "plugins": [
         ["@silvanite/tailwind", {
             config: "./tailwind.js"
+        }]
+    ]
+}
+```
+
+By default PurgeCSS will be applied when running vuepress build (production). You can optionally disable this if you do not want to use PurgeCSS.
+
+```js
+module.exports = {
+    ...
+    "plugins": [
+        ["@silvanite/tailwind", {
+            purgecss: { enabled: false }
         }]
     ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,8 @@ export default [
             format: 'cjs',
         },
         external: [
-            "path"
+            "path",
+            "lodash",
         ],
         plugins: [
             RollupPluginBabel(),

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,65 @@
 import path from 'path'
 
 const plugin = (options = {}, context) => {
-    const { themeConfig, siteConfig } = context
+    const { themeConfig, siteConfig, cwd, isProd } = context
     const { config } = options
 
-    siteConfig.postcss = Object.assign({
-        plugins: [
-            require("tailwindcss")(config || path.join(__dirname, "tailwind.config.js")),
-            require("autoprefixer")
+    const plugins = [
+        require("tailwindcss")(config || path.join(__dirname, "tailwind.config.js")),
+        require("autoprefixer"),
+    ]
+
+    /**
+     * Only run purge css in production.
+     */
+    if (isProd) plugins.push(require("@fullhuman/postcss-purgecss")({
+        content: [
+            `${cwd}/.vuepress/**/*.vue`,
+            `${cwd}/.vuepress/**/*.md`,
+            `${cwd}/.vuepress/**/*.js`,
+            `${cwd}/.vuepress/**/*.html`,
+            `${cwd}/.vuepress/**/*.styl`,
+            "!(node_modules)/**/*.*",
+        ],
+
+        extractors: [
+            {
+                /**
+                 * A fix for purge css to pick up class names with escaped chars
+                 * E.g. md:w-1/2.
+                 *
+                 * Solution from https://github.com/tailwindcss/tailwindcss/issues/391#issuecomment-366922730
+                 */
+                extractor: class TailwindExtractor {
+                    static extract(content) {
+                        return (
+                            content.match(/[A-z0-9-:\/]+/g) || []
+                        );
+                    }
+                },
+                extensions: [
+                    "css",
+                    "html",
+                    "js",
+                    "vue",
+                    "md",
+                    "styl"
+                ]
+            }
+        ],
+
+        /**
+         * Ensure default resets and normalised classes ar enot removed by PurgeCSS
+         */
+        whitelistPatterns: [
+            /^(h\d|p$|ul|li$|div|ol|table|td$|th$|thead|tbody|main|input|button|form|md-|hljs)/
         ]
-    }, siteConfig.postcss)
+    }))
+
+    /**
+     * Merge in the site's purgecss config
+     */
+    siteConfig.postcss = Object.assign(siteConfig.postcss || {}, { plugins })
 
     return {
         name: '@silvanite/vuepress-plugin-tailwind',

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ const plugin = (options = {}, context) => {
     /**
      * Merge in the site's purgecss config
      */
-    siteConfig.postcss = Object.assign(siteConfig.postcss || {}, { plugins })
+    siteConfig.postcss = merge(siteConfig.postcss || {}, { plugins })
 
     return {
         name: '@silvanite/vuepress-plugin-tailwind',

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,15 @@
 import path from 'path'
+import { merge } from 'lodash'
+
+const defaultOptions = {
+    purgecss: {
+        enabled: true,
+    },
+}
 
 const plugin = (options = {}, context) => {
     const { themeConfig, siteConfig, cwd, isProd } = context
-    const { config } = options
+    const { config, purgecss } = merge(defaultOptions, options)
 
     const plugins = [
         require("tailwindcss")(config || path.join(__dirname, "tailwind.config.js")),
@@ -12,7 +19,7 @@ const plugin = (options = {}, context) => {
     /**
      * Only run purge css in production.
      */
-    if (isProd) plugins.push(require("@fullhuman/postcss-purgecss")({
+    if (isProd && purgecss.enabled) plugins.push(require("@fullhuman/postcss-purgecss")({
         content: [
             `${cwd}/.vuepress/theme/**/*.*`,
             `${cwd}/!(node_modules)/**/*.md`,

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,8 @@ const plugin = (options = {}, context) => {
      */
     if (isProd) plugins.push(require("@fullhuman/postcss-purgecss")({
         content: [
-            `${cwd}/.vuepress/**/*.vue`,
-            `${cwd}/.vuepress/**/*.md`,
-            `${cwd}/.vuepress/**/*.js`,
-            `${cwd}/.vuepress/**/*.html`,
-            `${cwd}/.vuepress/**/*.styl`,
-            "!(node_modules)/**/*.*",
+            `${cwd}/.vuepress/theme/**/*.*`,
+            `${cwd}/!(node_modules)/**/*.md`,
         ],
 
         extractors: [


### PR DESCRIPTION
Adds PurgeCSS by default with a configuration option to disable it. It is only applied during the build phase, but not during the dev phase.

All files within the `.vuepress/theme` folder are scanned as well as any markdown files anywhere in the project.